### PR TITLE
feat: support TypeScript #121

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@alaskaairux/icons",
-  "version": "4.10.1",
+  "version": "4.11.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8646,7 +8646,8 @@
         },
         "hosted-git-info": {
           "version": "2.8.8",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
+          "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
           "dev": true
         },
         "normalize-package-data": {
@@ -11170,6 +11171,12 @@
       "requires": {
         "is-typedarray": "^1.0.0"
       }
+    },
+    "typescript": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
+      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
+      "dev": true
     },
     "typical": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "nodemon": "^2.0.15",
     "npm-run-all": "^4.1.5",
     "semantic-release": "^17.4.7",
-    "svglint": "^2.1.0"
+    "svglint": "^2.1.0",
+    "typescript": "^4.6.3"
   },
   "scripts": {
     "postinstall": "node packageScripts/postinstall.js",
@@ -39,7 +40,7 @@
     "copy:cssJs": "copyfiles -f ./src/tokens/*.js ./dist/tokens",
     "svglint": "svglint dist/icons/*.svg dist/icons/alert/*.svg dist/icons/in-flight/*.svg dist/icons/interface/*.svg dist/icons/shop/*.svg dist/icons/social/*.svg dist/icons/terminal/*.svg --ci",
     "generator": "node scripts/generate.js",
-    "generate": "npm-run-all sweep generator build:demo copy:dist",
+    "generate": "npm-run-all sweep generator build:demo copy:dist types",
     "test": "npm-run-all svgjest jsonlint svglint",
     "svgjest": "jest",
     "sweep": "rm -rf ./dist",
@@ -47,7 +48,8 @@
     "build": "npm-run-all sweep generate test copy:styles svgjest build:demo",
     "build:dev": "npm-run-all sweep generate build:demo test",
     "watch": "nodemon -e svg,js --watch src --exec npm-run-all generate test",
-    "serve": "web-dev-server --open demo/ --node-resolve --watch"
+    "serve": "web-dev-server --open demo/ --node-resolve --watch",
+    "types": "tsc"
   },
   "husky": {
     "hooks": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "include": ["dist/**/*.js"], // process the generated JS files from the SVGs
+  "exclude": [],
+  "compilerOptions": {
+    // Tells TypeScript to read JS files, as
+    // normally they are ignored as source files
+    "allowJs": true,
+    // Generate d.ts files
+    "declaration": true,
+    // This compiler run should
+    // only output d.ts files
+    "emitDeclarationOnly": true,
+    "outDir": "dist",
+    // go to js file when using IDE functions like
+    // "Go to Definition" in VSCode
+    "declarationMap": true
+  }
+}


### PR DESCRIPTION
# Alaska Airlines Pull Request

Fixes #121

## Summary:

Automatically generate `d.ts` files so the icons can be imported in TS projects without errors or manual typings. This will also improve autocomplete for people not using TS.

Tested in a freshly-scaffolded open-wc component and the icons can be imported without errors.

Since we specify `"main": "dist/index.js"` in the package.json and the `d.ts` files are in the same folder, the types should be picked up automatically by consuming IDEs.

## Type of change:

- [x] New capability

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
