### PR TITLE
Disable husky on release to prevent build failures

### DIFF
--- a/.github/workflows/testPublish.yml
+++ b/.github/workflows/testPublish.yml
@@ -48,3 +48,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          HUSKY: 0


### PR DESCRIPTION
# Alaska Airlines Pull Request

We need to disable husky on release because it's causing `commitlint` to throw an error. This only happens in release because the release is adding the git URL to the commit. It should be okay to disable husky on release, which is what other developers are doing. Please check the links below for more info.

See: 
https://github.com/typicode/husky/issues/920
&&
https://github.com/semantic-release/git/issues/209

**Fixes:** #152 

## Summary:

Sets an environment variable that disables husky only in the release pipeline.

## Type of change:

- [x] Release pipeline


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
