### PR TITLE
Fix demo building for windows filesystems

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ import Arrowdown from '-!svg-react-loader?name=Icon!@alaskaairux/icons/dist/icon
 
 Adding new icons to this repository requires a few steps.
 
-1. Node.js minimum version `12.x`
+1. Node.js minimum version `14.x`
 1. Add a new icon `.svg` file to the `src/icons/` directory (see Guidelines below)
 1. If the icons are to retain designed color specs, please place the new icon in the `src/icons/fullColor` directory
 1. Add **shape schema** to `./src/data/icons.json` file (see example below)

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "jsonlint": "jsonlint src/data/icons.json -q -V .jsonlintschema",
     "copy:styles": "npm-run-all copy:sass copy:css copy:cssJs",
     "copy:sass": "copyfiles -f ./src/*.scss ./dist",
-    "copy:dist": "copyfiles -V './dist/**/*.svg' ./demo/",
+    "copy:dist": "copyfiles -V \"./dist/**/*.svg\" ./demo/",
     "copy:css": "copyfiles -f ./src/tokens/*.css ./dist/tokens",
     "copy:cssJs": "copyfiles -f ./src/tokens/*.js ./dist/tokens",
     "svglint": "svglint dist/icons/*.svg dist/icons/alert/*.svg dist/icons/in-flight/*.svg dist/icons/interface/*.svg dist/icons/shop/*.svg dist/icons/social/*.svg dist/icons/terminal/*.svg --ci",

--- a/scripts/buildDemo.js
+++ b/scripts/buildDemo.js
@@ -1,38 +1,31 @@
-const { resolve, normalize } = require('path');
-const { readdir } = require('fs').promises;
 const fs = require('fs');
-const path = require('path');
+const path = require("path");
+const { readdir } = require('fs').promises;
 
 async function* getFiles(dir) {
   const dirents = await readdir(dir, { withFileTypes: true });
 
   for (const dirent of dirents) {
-    const res = resolve(dir, dirent.name);
+    const res = path.resolve(dir, dirent.name);
 
     if (dirent.isDirectory()) {
-      yield* getFiles(normalize(res));
+      yield* getFiles(path.normalize(res));
     } else {
-      yield res.replace(/\\/g, '/');
+      yield res;
     }
   }
-}
-
-const getFile = (filePath) => {
-    const dirs = filePath.split('/');
-
-    return dirs[dirs.length -1];
 }
 
 const buildElements = (sortedIcons) => {
 
   let allCategories = '';
 
-  for(let category in sortedIcons) {
+  for (let category in sortedIcons) {
     let iconPaths = sortedIcons[category];
     let elements = "";
 
     iconPaths.forEach(i => {
-      const file = getFile(i);
+      const file = path.basename(i);
       elements += `
         <div class="block" title="${file}">
           <img src="./dist/icons/${category}/${file}" alt="">
@@ -59,7 +52,7 @@ const buildLogos = (logos) => {
   let elements = "";
 
   logos.forEach(i => {
-    const file = getFile(i);
+    const file = path.basename(i);
     elements += `
       <div class="block block--large" title="${i}">
         <img src="./dist/logos/${file}" alt="">
@@ -72,11 +65,10 @@ const buildLogos = (logos) => {
 }
 
 const buildRestricted = (logos) => {
-
   let elements = "";
 
   logos.forEach(i => {
-    const file = getFile(i);
+    const file = path.basename(i);
     elements += `
       <div class="block block--large" title="${i}">
         <img src="./dist/restricted/${file}" alt="">
@@ -89,36 +81,33 @@ const buildRestricted = (logos) => {
 }
 
 const getCategory = (iconPath) => {
-
-  const iconAndDist = iconPath.split('icons/')[1];
+  const iconAndDist = iconPath.split(`icons${path.sep}`)[1];
   let category = '';
-
-  if(iconAndDist.includes('/')) category = iconAndDist.split('/')[0];
+  if (iconAndDist.includes(path.sep)) category = iconAndDist.split(path.sep)[0];
 
   return category;
 }
 
 
 (async () => {
-  const icons = [];
-  for await (const file of getFiles('./dist/icons')) {
-    const currentPath = path.join(__dirname, '../dist')
+  const currentPath = path.join(__dirname, '..', 'dist');
 
-    if(file.includes('.svg')) icons.push(file.split(currentPath)[1]);
+  const icons = [];
+  const iconPath = path.join(__dirname, "..", 'dist', 'icons');
+  for await (const file of getFiles(iconPath)) {
+    if (file.includes('.svg')) icons.push(file.split(currentPath)[1]);
   }
 
   const logos = [];
-  for await (const file of getFiles('./dist/logos')) {
-    const currentPath = path.join(__dirname, '../dist/logos/')
-
-    if(file.includes('.svg')) logos.push(file.split(currentPath)[1]);
+  const logoPath = path.join(__dirname, "..", 'dist', 'logos');
+  for await (const file of getFiles(logoPath)) {
+    if (file.includes('.svg')) logos.push(file.split(currentPath)[1]);
   }
 
   const restricted = [];
-  for await (const file of getFiles('./dist/restricted')) {
-    const currentPath = path.join(__dirname, '../dist/restricted/')
-
-    if(file.includes('.svg')) restricted.push(file.split(currentPath)[1]);
+  const restrictedPath = path.join(__dirname, "..", 'dist', 'restricted');
+  for await (const file of getFiles(restrictedPath)) {
+    if (file.includes('.svg')) restricted.push(file.split(currentPath)[1]);
   }
 
   const sortedIcons = {};
@@ -126,7 +115,7 @@ const getCategory = (iconPath) => {
   icons.forEach(i => {
     const category = getCategory(i);
 
-    if(!sortedIcons[category]) sortedIcons[category] = [];
+    if (!sortedIcons[category]) sortedIcons[category] = [];
     sortedIcons[category].push(i);
   });
 
@@ -185,13 +174,13 @@ const getCategory = (iconPath) => {
 
   const dir = './demo';
 
-  if (!fs.existsSync(dir)){
+  if (!fs.existsSync(dir)) {
     fs.mkdirSync(dir);
   }
 
   fs.writeFile("./demo/index.html", iconListComponentText, (err) => {
 
-    if(err) return console.log(err);
+    if (err) return console.log(err);
 
     console.log("The file was saved!");
   });


### PR DESCRIPTION
# Alaska Airlines Pull Request
This PR should resolve some issues that I was having running the demo project on a windows filesystem. There are also some minor improvements made to how we reference files.

I tested this on both windows and macos, and it works great on both ends now! 🎉

**Fixes:** #153 

## Summary:

This change updates a lot of our path references to use `path.join` so that our path references are not os specific.

Also found a bug with the `copyfiles` dependency requiring us to use double quotes on glob references for windows filesystems. See [this link](https://github.com/calvinmetcalf/copyfiles/issues/61) for more info.

## Type of change:

- [ ] New capability
- [ ] Revision of an existing capability
- [x] Infrastructure change (automation, etc.)
- [ ] Other (please elaborate)


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
