### PR TITLE
Drop node 18 support and officially support `20 || 22`

### DIFF
--- a/.github/workflows/testPublish.yml
+++ b/.github/workflows/testPublish.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [20, 22]
 
     steps:
       - uses: actions/checkout@v4
@@ -39,7 +39,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
       - run: npm ci
       - run: npm run generate
       - run: npm run copy:styles

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@alaskaairux/icons",
-  "version": "4.43.0",
+  "version": "4.44.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@alaskaairux/icons",
-      "version": "4.43.0",
+      "version": "4.44.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -31,7 +31,7 @@
         "typescript": "^5.5.4"
       },
       "engines": {
-        "node": "^18 || ^20"
+        "node": "^20 || ^22"
       }
     },
     "node_modules/@75lb/deep-merge": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Alaska Design and Research",
   "license": "Apache-2.0",
   "engines": {
-    "node": "^18 || ^20"
+    "node": "^20 || ^22"
   },
   "type": "commonjs",
   "repository": {


### PR DESCRIPTION
BREAKING CHANGE: drops support for node 18

Official EOL is in April 2025, and we as the Auro team need to lead the curve as the upstream.

SOURCE: https://nodejs.org/en/blog/release/v18.12.0

# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

**Resolves:** # (issue, if applicable)

## Summary:

_Please summarize the scope of the changes you have submitted, what the intent of the work is and anything that describes the before/after state of the project._

## Type of change:

- [x] Infrastructure change (automation, etc.)


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Build:
- Update Node.js versions in the test and publish workflow to use Node.js 20 and 22.