### PR TITLE
feat: add default airplane tail icon AB#1497875

### DIFF
--- a/src/data/logoIcons.json
+++ b/src/data/logoIcons.json
@@ -311,6 +311,11 @@
       "viewBox": "0 0 856 830"
     },
     {
+      "name": "tail-default",
+      "title": "Airplane tail default image with light gray color",
+      "viewBox": "0 0 142 138"
+    },
+    {
       "name": "tail-EI",
       "title": "Airplane tail image for Aer Lingus",
       "viewBox": "0 0 856 830"

--- a/src/icons/logos/tail-default.svg
+++ b/src/icons/logos/tail-default.svg
@@ -1,0 +1,9 @@
+<svg width="142" height="138" viewBox="0 0 142 138" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M124.093 14.6652C125.892 14.6652 127.35 16.1263 127.35 17.9286C127.35 18.1214 127.333 18.3102 127.301 18.4938L101.097 119.85C100.627 120.937 98.8856 123.248 95.4049 123.321L95.2989 123.322L14.6499 123.335C70.6624 53.0584 98.8059 17.7507 99.0802 17.4122C100.294 15.9145 102.355 14.6899 104.452 14.6652H124.093Z" fill="url(#paint0_linear_9225_2069)"/>
+<defs>
+<linearGradient id="paint0_linear_9225_2069" x1="114.823" y1="14.6652" x2="60.0608" y2="123.335" gradientUnits="userSpaceOnUse">
+<stop offset="0.5" stop-color="#707984"/>
+<stop offset="0.5" stop-color="#646E7B"/>
+</linearGradient>
+</defs>
+</svg>


### PR DESCRIPTION
# Alaska Airlines Pull Request

Adds a default `auro-tail` icon:

<img width="826" height="568" alt="Screenshot 2026-02-27 at 12 18 04 PM" src="https://github.com/user-attachments/assets/ec879d76-bb1d-4468-a5f4-0ec7d799dab3" />

**Resolves:** #AB1497875

## Summary:

_Please summarize the scope of the changes you have submitted, what the intent of the work is and anything that describes the before/after state of the project._

## Type of change:

- [X] New capability
- [ ] Revision of an existing capability
- [ ] Infrastructure change (automation, etc.)
- [ ] Other (please elaborate)


## Checklist:

- [X] My update follows the CONTRIBUTING guidelines of this project
- [X] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

New Features:
- Introduce a default tail logo SVG asset for use across the design system.